### PR TITLE
Limit CI test platforms to Linux

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -14,7 +14,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ "3.11" ]
 
     uses: darbiadev/.github/.github/workflows/python-test.yaml@4aa7c64159244d12bf9a39d42da89e80004d4af6 # v1.0.1


### PR DESCRIPTION
This library is only being used on Linux currently.