### PR TITLE
Construct Package directly in get_package_metadata

### DIFF
--- a/src/letsbuilda/pypi/async_client.py
+++ b/src/letsbuilda/pypi/async_client.py
@@ -7,7 +7,7 @@ import xmltodict
 from httpx import AsyncClient
 
 from .exceptions import PackageNotFoundError
-from .models import JSONPackageMetadata, Package, RSSPackageMetadata
+from .models import Distribution, JSONPackageMetadata, Package, Release, RSSPackageMetadata
 
 
 class PyPIServices:
@@ -89,6 +89,13 @@ class PyPIServices:
         Package
             The package object.
         """
-        return Package.model_validate(
-            (await self.get_package_json_metadata(package_title, package_version)).model_dump(),
+        metadata = await self.get_package_json_metadata(package_title, package_version)
+        return Package(
+            title=metadata.info.name,
+            releases=[
+                Release(
+                    version=metadata.info.version,
+                    distributions=[Distribution(filename=url.filename, url=url.url) for url in metadata.urls],
+                ),
+            ],
         )

--- a/src/letsbuilda/pypi/models/__init__.py
+++ b/src/letsbuilda/pypi/models/__init__.py
@@ -1,11 +1,13 @@
 """Models to hold the data."""
 
 from .models_json import JSONPackageMetadata
-from .models_package import Package
+from .models_package import Distribution, Package, Release
 from .models_rss import RSSPackageMetadata
 
 __all__ = [
+    "Distribution",
     "JSONPackageMetadata",
     "Package",
+    "Release",
     "RSSPackageMetadata",
 ]

--- a/src/letsbuilda/pypi/models/__init__.py
+++ b/src/letsbuilda/pypi/models/__init__.py
@@ -8,6 +8,6 @@ __all__ = [
     "Distribution",
     "JSONPackageMetadata",
     "Package",
-    "Release",
     "RSSPackageMetadata",
+    "Release",
 ]

--- a/src/letsbuilda/pypi/sync_client.py
+++ b/src/letsbuilda/pypi/sync_client.py
@@ -7,7 +7,7 @@ import xmltodict
 from httpx import Client
 
 from .exceptions import PackageNotFoundError
-from .models import JSONPackageMetadata, Package, RSSPackageMetadata
+from .models import Distribution, JSONPackageMetadata, Package, Release, RSSPackageMetadata
 
 
 class PyPIServices:
@@ -89,4 +89,13 @@ class PyPIServices:
         Package
             The package object.
         """
-        return Package.model_validate(self.get_package_json_metadata(package_title, package_version).model_dump())
+        metadata = self.get_package_json_metadata(package_title, package_version)
+        return Package(
+            title=metadata.info.name,
+            releases=[
+                Release(
+                    version=metadata.info.version,
+                    distributions=[Distribution(filename=url.filename, url=url.url) for url in metadata.urls],
+                ),
+            ],
+        )

--- a/tests/test_get_package_metadata.py
+++ b/tests/test_get_package_metadata.py
@@ -1,0 +1,45 @@
+"""Test building a `Package` from the JSON API in `get_package_metadata`."""
+
+import asyncio
+
+import httpx
+from test_json_api_parsing import JSON_API_DATA
+
+from letsbuilda.pypi import Package
+from letsbuilda.pypi.async_client import PyPIServices as AsyncPyPIServices
+from letsbuilda.pypi.sync_client import PyPIServices as SyncPyPIServices
+
+
+def _handler(_: httpx.Request) -> httpx.Response:
+    """Return the sample JSON API data for any request."""
+    return httpx.Response(200, json=JSON_API_DATA)
+
+
+def _assert_package(package: Package) -> None:
+    """Confirm the sample data is mapped onto a `Package` correctly."""
+    assert package.title == "letsbuilda-pypi"
+    assert len(package.releases) == 1
+
+    release = package.releases[0]
+    assert release.version == "4.0.0"
+    assert [distribution.filename for distribution in release.distributions] == [
+        "letsbuilda_pypi-4.0.0-py3-none-any.whl",
+        "letsbuilda-pypi-4.0.0.tar.gz",
+    ]
+
+
+def test_sync_get_package_metadata() -> None:
+    """Confirm the sync client builds a `Package` from the JSON API data."""
+    client = httpx.Client(transport=httpx.MockTransport(_handler))
+    package = SyncPyPIServices(client).get_package_metadata("letsbuilda-pypi")
+    _assert_package(package)
+
+
+def test_async_get_package_metadata() -> None:
+    """Confirm the async client builds a `Package` from the JSON API data."""
+
+    async def _run() -> Package:
+        async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+            return await AsyncPyPIServices(client).get_package_metadata("letsbuilda-pypi")
+
+    _assert_package(asyncio.run(_run()))


### PR DESCRIPTION
## Summary

PR #104 replaced the previous `from_json_api_data` logic with a generic `Package.model_validate(get_package_json_metadata(...).model_dump())`. This is incorrect: a `JSONPackageMetadata` dump has the shape `{info, last_serial, urls, vulnerabilities}`, whereas `Package` expects `{title, releases}`. The generic validation cannot map one onto the other.

This makes the smallest surgical change to construct the `Package` directly in `get_package_metadata`, restoring the original mapping from the JSON API data:

```python
metadata = self.get_package_json_metadata(package_title, package_version)
return Package(
    title=metadata.info.name,
    releases=[
        Release(
            version=metadata.info.version,
            distributions=[Distribution(filename=url.filename, url=url.url) for url in metadata.urls],
        ),
    ],
)
```

## Changes

- `models/__init__.py` — export `Distribution` and `Release` so the clients can import them.
- `sync_client.py` / `async_client.py` — build `Package` directly from the JSON metadata instead of `model_validate(...model_dump())`.

## Testing

- Verified the construction produces a correct `Package` from the existing JSON API test fixture.
- `pytest` — all 3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwR4fwsPEMmgHF3kucJqbK

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwR4fwsPEMmgHF3kucJqbK)_